### PR TITLE
removing intermittent checks

### DIFF
--- a/workspace/Utilities/cpp/unitTest/src/Semaphore_unit.cc
+++ b/workspace/Utilities/cpp/unitTest/src/Semaphore_unit.cc
@@ -78,14 +78,10 @@ namespace Tests
             if(i % 2 == 0)
             {
                 threads[i] = std::thread(&Waiter, pCommon);
-                std::this_thread::sleep_for(std::chrono::seconds(1));
-                EXPECT_EQ(--count, pCommon->_sem.GetCount());
             }
             else
             {
                 threads[i] = std::thread(&Signaler, pCommon);
-                std::this_thread::sleep_for(std::chrono::seconds(1));
-                EXPECT_EQ(++count, pCommon->_sem.GetCount());
             }
         }
         if(numThreads % 2 != 0)


### PR DESCRIPTION
proof of Semaphore count is if the test doesn't hang
